### PR TITLE
fix copy plain text of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple web-based file sharing built with Flask.
 - Download and delete uploaded files
 - Batch download selected files by clicking rows to select
 - Comment board with colored messages
-- Copy comment text exactly as written, preserving all line breaks while stripping HTML tags
+- Copy comment text exactly as written, preserving all line breaks
 - Server logs record what each IP does
 
 ### Usage
@@ -28,7 +28,7 @@ Simple web-based file sharing built with Flask.
 - 可下载或删除已上传的文件
 - 支持点击行选择并批量下载
 - 内置留言板并为不同 IP 分配颜色
-- 留言复制时完全保留换行并去除 HTML 标签
+- 留言复制时完全保留换行
 - 记录各个 IP 的操作日志
 
 ### 使用方法
@@ -46,7 +46,7 @@ Flask で作られたシンプルなファイル共有ツールです。
 - アップロードしたファイルのダウンロードと削除
 - 行をクリックして複数のファイルをまとめてダウンロード
 - IP ごとに色が変わる掲示板
-- コメントをコピーする際、改行を完全に保ったまま HTML タグを除去
+- コメントをコピーする際、改行を完全に保持
 - 各 IP の操作履歴を記録
 
 ### 使い方

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple web-based file sharing built with Flask.
 - Download and delete uploaded files
 - Batch download selected files by clicking rows to select
 - Comment board with colored messages
-- Copy comment text to clipboard without HTML tags, preserving line breaks
+- Copy comment text exactly as written, preserving all line breaks while stripping HTML tags
 - Server logs record what each IP does
 
 ### Usage
@@ -28,7 +28,7 @@ Simple web-based file sharing built with Flask.
 - 可下载或删除已上传的文件
 - 支持点击行选择并批量下载
 - 内置留言板并为不同 IP 分配颜色
-- 留言复制保持换行并去除 HTML 标签
+- 留言复制时完全保留换行并去除 HTML 标签
 - 记录各个 IP 的操作日志
 
 ### 使用方法
@@ -46,7 +46,7 @@ Flask で作られたシンプルなファイル共有ツールです。
 - アップロードしたファイルのダウンロードと削除
 - 行をクリックして複数のファイルをまとめてダウンロード
 - IP ごとに色が変わる掲示板
-- コメントをコピーする際に改行を保ったまま HTML タグを除去
+- コメントをコピーする際、改行を完全に保ったまま HTML タグを除去
 - 各 IP の操作履歴を記録
 
 ### 使い方

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple web-based file sharing built with Flask.
 - Download and delete uploaded files
 - Batch download selected files by clicking rows to select
 - Comment board with colored messages
-- Copy comment text exactly as written, preserving all line breaks
+- Copy comment text exactly as written, preserving spaces and line breaks
 - Server logs record what each IP does
 
 ### Usage
@@ -28,7 +28,7 @@ Simple web-based file sharing built with Flask.
 - 可下载或删除已上传的文件
 - 支持点击行选择并批量下载
 - 内置留言板并为不同 IP 分配颜色
-- 留言复制时完全保留换行
+- 留言复制时完全保留空格和换行
 - 记录各个 IP 的操作日志
 
 ### 使用方法
@@ -46,7 +46,7 @@ Flask で作られたシンプルなファイル共有ツールです。
 - アップロードしたファイルのダウンロードと削除
 - 行をクリックして複数のファイルをまとめてダウンロード
 - IP ごとに色が変わる掲示板
-- コメントをコピーする際、改行を完全に保持
+- コメントをコピーするとき、空白と改行をそのまま維持
 - 各 IP の操作履歴を記録
 
 ### 使い方

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Simple web-based file sharing built with Flask.
 - Download and delete uploaded files
 - Batch download selected files by clicking rows to select
 - Comment board with colored messages
+- Copy comment text to clipboard without HTML tags, preserving line breaks
 - Server logs record what each IP does
 
 ### Usage
@@ -27,6 +28,7 @@ Simple web-based file sharing built with Flask.
 - 可下载或删除已上传的文件
 - 支持点击行选择并批量下载
 - 内置留言板并为不同 IP 分配颜色
+- 留言复制保持换行并去除 HTML 标签
 - 记录各个 IP 的操作日志
 
 ### 使用方法
@@ -44,6 +46,7 @@ Flask で作られたシンプルなファイル共有ツールです。
 - アップロードしたファイルのダウンロードと削除
 - 行をクリックして複数のファイルをまとめてダウンロード
 - IP ごとに色が変わる掲示板
+- コメントをコピーする際に改行を保ったまま HTML タグを除去
 - 各 IP の操作履歴を記録
 
 ### 使い方

--- a/ftp.py
+++ b/ftp.py
@@ -299,10 +299,11 @@ def index(username):
     </script>
     <script>
 function copyToClipboard(text) {
-  // Strip HTML tags when copying comment text
-  const tempDiv = document.createElement('div');
-  tempDiv.innerHTML = text;
-  const plainText = tempDiv.textContent || tempDiv.innerText || '';
+  // Strip HTML tags when copying comment text but preserve line breaks
+  const plainText = text
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<[^>]+>/g, '');
   if (navigator.clipboard && navigator.clipboard.writeText) {
     // Modern approach using Clipboard API
     navigator.clipboard.writeText(plainText).then(function() {

--- a/ftp.py
+++ b/ftp.py
@@ -298,12 +298,11 @@ def index(username):
       }
     </script>
     <script>
-function copyToClipboard(text) {
-  // Strip HTML tags when copying comment text but preserve line breaks
-  const plainText = text
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n')
-    .replace(/<[^>]+>/g, '');
+function copyToClipboard(html) {
+  // Convert the HTML comment to plain text using the browser to keep line breaks
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = html;
+  let plainText = tempDiv.innerText.replace(/\u00A0/g, ' ');
   if (navigator.clipboard && navigator.clipboard.writeText) {
     // Modern approach using Clipboard API
     navigator.clipboard.writeText(plainText).then(function() {

--- a/ftp.py
+++ b/ftp.py
@@ -300,7 +300,7 @@ def index(username):
     </script>
     <script>
 function copyToClipboard(text) {
-  const plainText = text;
+  const plainText = text.replace(/\u00A0/g, ' ');
   if (navigator.clipboard && navigator.clipboard.writeText) {
     // Modern approach using Clipboard API
     navigator.clipboard.writeText(plainText).then(function() {
@@ -540,7 +540,7 @@ function showCopyMessage(message) {
       var quill = new Quill('#editor', { theme: 'snow' });
       function submitComment() {
         document.getElementById('commentInput').value = quill.root.innerHTML;
-        document.getElementById('commentPlainInput').value = quill.getText();
+        document.getElementById('commentPlainInput').value = quill.getText().replace(/\u00A0/g, ' ');
         return true;
       }
     </script>

--- a/ftp.py
+++ b/ftp.py
@@ -299,9 +299,13 @@ def index(username):
     </script>
     <script>
 function copyToClipboard(text) {
+  // Strip HTML tags when copying comment text
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = text;
+  const plainText = tempDiv.textContent || tempDiv.innerText || '';
   if (navigator.clipboard && navigator.clipboard.writeText) {
     // Modern approach using Clipboard API
-    navigator.clipboard.writeText(text).then(function() {
+    navigator.clipboard.writeText(plainText).then(function() {
       showCopyMessage('Comment copied to clipboard!');
     }).catch(function(err) {
       alert('Failed to copy comment: ' + err);
@@ -309,7 +313,7 @@ function copyToClipboard(text) {
   } else {
     // Fallback approach for older browsers
     const textArea = document.createElement('textarea');
-    textArea.value = text;
+    textArea.value = plainText;
     textArea.style.position = 'fixed'; // Avoid scrolling to bottom
     textArea.style.left = '-9999px';
     document.body.appendChild(textArea);


### PR DESCRIPTION
## Summary
- ensure comment copy button strips HTML before copying

## Testing
- `python -m py_compile ftp.py`

------
https://chatgpt.com/codex/tasks/task_e_686787dd96bc8320a60280c2fc064704